### PR TITLE
golang-http-exam2 to 0.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -7,6 +7,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.82
+- name: golang-http-exam2
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.3
 - name: spring-demo
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.1


### PR DESCRIPTION
Promote golang-http-exam2 to version 0.0.3